### PR TITLE
Use different tmp file per instance

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@wasmer/wasm-transformer": "^0.7.1",
     "binaryen": "^90.0.0",
     "chalk": "^3.0.0",
+    "tmp": "^0.2.1",
     "yargs": "^15.1.0"
   }
 }

--- a/wasm-trace.js
+++ b/wasm-trace.js
@@ -17,12 +17,11 @@ const chalk = require("chalk");
 const assert = require('assert').strict;
 const readline = require('readline');
 const stream = require('stream');
+const tmp = require('tmp');
 
 const Wasi = require("@wasmer/wasi");
 const Node = require("@wasmer/wasi/lib/bindings/node");
 const Binaryen = require("binaryen");
-
-const csvTraceFn = ".wasm-trace.csv";
 
 /*
  * Arguments
@@ -166,6 +165,7 @@ function log(msg) {
   binary = await WasmTransformer.lowerI64Imports(binary);
   */
 
+  const csvTraceFn = tmp.tmpNameSync({prefix: '.wasm-trace', postfix: '.csv', tmpdir: './'});
   const csv_output = fs.createWriteStream(csvTraceFn);
   await execute(binary, csv_output, argv)
   csv_output.end();


### PR DESCRIPTION
csvTraceFn always defaults to ".wasm-trace.csv". This means that
multiple instances of wasm-trace in the same directory conflict with
each other.

With this patch, the tmp module is used to generate a unique file name
for each invocation.